### PR TITLE
:sparkles: NetworkManager as Protocol and Interactor init parameter

### DIFF
--- a/Module VIPER.xctemplate/Storyboard/___FILEBASENAME___Interactor.swift
+++ b/Module VIPER.xctemplate/Storyboard/___FILEBASENAME___Interactor.swift
@@ -10,8 +10,12 @@ import Foundation
 
 class ___VARIABLE_productName:identifier___Interactor {
 
-	let networkManager = ___VARIABLE_productName:identifier___NetworkManager()
+	fileprivate let networkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol
     weak var output: ___VARIABLE_productName:identifier___InteractorOutput?
+
+    init(networkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol = ___VARIABLE_productName:identifier___NetworkManager()){
+        self.networkManager = networkManager
+    }
 }
 
 extension ___VARIABLE_productName:identifier___Interactor: ___VARIABLE_productName:identifier___InteractorProtocol {

--- a/Module VIPER.xctemplate/Storyboard/___FILEBASENAME___NetworkManager.swift
+++ b/Module VIPER.xctemplate/Storyboard/___FILEBASENAME___NetworkManager.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-class ___VARIABLE_productName:identifier___NetworkManager {
+class ___VARIABLE_productName:identifier___NetworkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol {
 
 }

--- a/Module VIPER.xctemplate/Storyboard/___FILEBASENAME___Protocols.swift
+++ b/Module VIPER.xctemplate/Storyboard/___FILEBASENAME___Protocols.swift
@@ -34,3 +34,7 @@ protocol ___VARIABLE_productName:identifier___InteractorOutput: AnyObject {
 protocol ___VARIABLE_productName:identifier___UI: AnyObject {
 
 }
+
+protocol ___VARIABLE_productName:identifier___NetworkManagerProtocol: AnyObject {
+
+}

--- a/Module VIPER.xctemplate/StoryboardWithDelegate/___FILEBASENAME___Interactor.swift
+++ b/Module VIPER.xctemplate/StoryboardWithDelegate/___FILEBASENAME___Interactor.swift
@@ -10,8 +10,12 @@ import Foundation
 
 class ___VARIABLE_productName:identifier___Interactor {
 
-	let networkManager = ___VARIABLE_productName:identifier___NetworkManager()
+	fileprivate let networkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol
     weak var output: ___VARIABLE_productName:identifier___InteractorOutput?
+
+    init(networkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol = ___VARIABLE_productName:identifier___NetworkManager()){
+        self.networkManager = networkManager
+    }
 }
 
 extension ___VARIABLE_productName:identifier___Interactor: ___VARIABLE_productName:identifier___InteractorProtocol {

--- a/Module VIPER.xctemplate/StoryboardWithDelegate/___FILEBASENAME___NetworkManager.swift
+++ b/Module VIPER.xctemplate/StoryboardWithDelegate/___FILEBASENAME___NetworkManager.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-class ___VARIABLE_productName:identifier___NetworkManager {
+class ___VARIABLE_productName:identifier___NetworkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol {
 
 }

--- a/Module VIPER.xctemplate/StoryboardWithDelegate/___FILEBASENAME___Protocols.swift
+++ b/Module VIPER.xctemplate/StoryboardWithDelegate/___FILEBASENAME___Protocols.swift
@@ -34,3 +34,7 @@ protocol ___VARIABLE_productName:identifier___InteractorOutput: AnyObject {
 protocol ___VARIABLE_productName:identifier___Delegate: class {
 
 }
+
+protocol ___VARIABLE_productName:identifier___NetworkManagerProtocol: AnyObject {
+
+}

--- a/Module VIPER.xctemplate/XIB/___FILEBASENAME___Interactor.swift
+++ b/Module VIPER.xctemplate/XIB/___FILEBASENAME___Interactor.swift
@@ -10,8 +10,12 @@ import Foundation
 
 class ___VARIABLE_productName:identifier___Interactor {
 
-	let networkManager = ___VARIABLE_productName:identifier___NetworkManager()
+	fileprivate let networkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol
     weak var output: ___VARIABLE_productName:identifier___InteractorOutput?
+
+    init(networkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol = ___VARIABLE_productName:identifier___NetworkManager()){
+        self.networkManager = networkManager
+    }
 }
 
 extension ___VARIABLE_productName:identifier___Interactor: ___VARIABLE_productName:identifier___InteractorProtocol {

--- a/Module VIPER.xctemplate/XIB/___FILEBASENAME___NetworkManager.swift
+++ b/Module VIPER.xctemplate/XIB/___FILEBASENAME___NetworkManager.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-class ___VARIABLE_productName:identifier___NetworkManager {
+class ___VARIABLE_productName:identifier___NetworkManager: ___VARIABLE_productName:identifier___NetworkManagerProtocol {
 
 }

--- a/Module VIPER.xctemplate/XIB/___FILEBASENAME___Protocols.swift
+++ b/Module VIPER.xctemplate/XIB/___FILEBASENAME___Protocols.swift
@@ -35,3 +35,6 @@ protocol ___VARIABLE_productName:identifier___Delegate: class {
     
 }
 
+protocol ___VARIABLE_productName:identifier___NetworkManagerProtocol: AnyObject {
+
+}


### PR DESCRIPTION
Card reference:

- [https://tracker.vidiemme.it/issues/13225](https://tracker.vidiemme.it/issues/13225)
- [https://tracker.vidiemme.it/issues/13226](https://tracker.vidiemme.it/issues/13226)

Use a Protocol to handle the NetworkManager
NetworkManager passed in Interactor init

Updated on:

- Storyboard with delegate
- Storyboard without delegate
- XIB (with delegate)